### PR TITLE
ethereum_for_ubuntu : Corrections du soir

### DIFF
--- a/_posts/2017-10-31-ethereum_for_ubuntu.md
+++ b/_posts/2017-10-31-ethereum_for_ubuntu.md
@@ -120,7 +120,7 @@ Pour utiliser un _chemin d'accès_, Path, personnalisé :
 $ parity --config path/to/config.toml
 ```
 
-Ou télécharger le TOML depuis le [générateur de configuration](https://paritytech.github.io/parity-config-generator/) et dans le termilan effectuer:
+Ou télécharger le TOML depuis le [générateur de configuration](https://paritytech.github.io/parity-config-generator/) et dans le terminal effectuer:
 ```
 cp /home/mon_espace_de_travail/Téléchargements/config.toml ~/.local/share/io.parity.ethereum
 ````

--- a/_posts/2017-10-31-ethereum_for_ubuntu.md
+++ b/_posts/2017-10-31-ethereum_for_ubuntu.md
@@ -135,7 +135,7 @@ Afin d'exécuter une chaîne différente de celle de l'Ethereum public officiel,
 Chaînes prédéfinies disponibles
 
 + [mainnet](https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/foundation.json) (par défaut) réseau principal Ethereum
-+ [kovan | testnet](https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/kovan.json) le [réseau de test rapide Ethereum](https://github.com/kovan-testnet/config)
++ [kovan \| testnet](https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/kovan.json) le [réseau de test rapide Ethereum](https://github.com/kovan-testnet/config)
 + [ropsten](https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/ropsten.json) l'ancien réseau de test Ethereum
 + réseau classique [Ethereum Classic](https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/classic.json)
 + [testnet Morden](https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/morden.json) original classique-testnet et Testnet Ethereum Classic actuel

--- a/_posts/2017-10-31-ethereum_for_ubuntu.md
+++ b/_posts/2017-10-31-ethereum_for_ubuntu.md
@@ -56,7 +56,7 @@ Pour [Ethereum](https://fr.wikipedia.org/wiki/Ethereum), qui est un protocole d'
 `geth`  est l'interface de ligne de commande pour un noeud ethereum complet implémenté dans Go. C'est le livrable principal de [Frontier Release](https://github.com/ethereum/go-ethereum/wiki/Frontier)
 
 
-En installant et en exécutant `get`, vous pouvez participer au réseau live de ethereum
+En installant et en exécutant `geth`, vous pouvez participer au réseau live de ethereum
 
 + miner  des vrais éthers
 + transférer des fonds entre les adresses

--- a/_posts/2017-10-31-ethereum_for_ubuntu.md
+++ b/_posts/2017-10-31-ethereum_for_ubuntu.md
@@ -144,10 +144,10 @@ Chaînes prédéfinies disponibles
 
 
 > Voilà vous êtes dans l'Ether...
-> La prochaine étape serade "miner"... dans le prochain article sur ce blog
+> La prochaine étape sera de "miner"... dans le prochain article sur ce blog
 
 
 ##### Voir également
 
 + [Qu'est ce que la blockchain](https://blockchainfrance.net/decouvrir-la-blockchain/c-est-quoi-la-blockchain/)
-+ Libre blanc sur a blockchain,  Lire l’étude (en anglais et PDF) : « [Blockchain & Beyond](https://blockchainfrance.net/2015/12/05/livre-blanc-cellabz/) »
++ Libre blanc sur la blockchain,  Lire l’étude (en anglais et PDF) : « [Blockchain & Beyond](https://blockchainfrance.net/2015/12/05/livre-blanc-cellabz/) »


### PR DESCRIPTION
A moins qu'il y ait une commande `get` dans geth, il manque un `h` (-: