### PR TITLE
Liberapay icon on the right side

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,6 +22,6 @@ layout: default
   <div class="post-content">
     {{ content }}
   </div>
- <right><script src="https://liberapay.com/Xav.CC/widgets/button.js"></script></right>
+  <div style="float:right;"><script src="https://liberapay.com/Xav.CC/widgets/button.js"></script></div>
 
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,12 +52,13 @@ layout: default
     </a>
   {% endif %}
   </footer>
-    <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
-        <a rel="license"
-           href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr">
-          <img src="/images/by-sa.svg" style="border-style: none;" alt="CC BY SA" />
-         </a>
-    
-     <right><script src="https://liberapay.com/Xav.CC/widgets/button.js"></script></right>
+  <div style="margin-bottom:10px;">
+    <div xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#" style="display:inline-block;">
+      <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr">
+        <img src="/images/by-sa.svg" style="border-style: none;" alt="CC BY SA" />
+      </a>
+    </div>
+    <div style="float:right; margin-bottom:10px;"><script src="https://liberapay.com/Xav.CC/widgets/button.js"></script></div>
+  </div>
 
 </article>


### PR DESCRIPTION
Fix issue #30
I rewrote the markup of the licence and liberapay buttons a bit (missing closing tag, wrong use of < p >, < right > doesn't exist).

Consider moving those buttons to the site footer instead of having them on each page and post.
  